### PR TITLE
bugfix: AVX2 scalar fallback (logn < 4) should use (Q-1)>>1

### DIFF
--- a/mq.c
+++ b/mq.c
@@ -1156,7 +1156,7 @@ avx2_mqpoly_sqnorm_ext(unsigned logn, const uint16_t *a)
 		uint32_t sat = 0;
 		for (size_t i = 0; i < n; i ++) {
 			uint32_t x = a[i];
-			x -= Q & ((((Q - 1) >> 2) - x) >> 16);
+			x -= Q & ((((Q - 1) >> 1) - x) >> 16);
 			int32_t y = *(int32_t *)&x;
 			s += (uint32_t)(y * y);
 			sat |= s;


### PR DESCRIPTION
The squared-norm normalization threshold in `avx2_mqpoly_sqnorm_ext()` (the scalar fallback branch taken when `logn < 4`) still uses `(Q - 1) >> 2`, whereas it should be `(Q - 1) >> 1`. I compared it with rust-fn-dsa's [mq_avx2.rs](https://github.com/pornin/rust-fn-dsa/blob/main/fn-dsa-comm/src/mq_avx2.rs#L823) which is using `>> 1`.

This is the same bug that was fixed in `mqpoly_sqnorm_ext()` by commit 9f85c2f ("Bugfix: wrong norm (verifier was too strict)"). That fix corrected the scalar function and the AVX2 *vectorized* path already used the correct `(Q - 1) >> 1`, but the AVX2 function's `logn < 4` scalar fallback was missed.

This only affects AVX2 builds, and only the `logn < 4` (degree 4 and 8) paths - i.e. the weak/research degrees. Standard parameters (logn 9/10) take the vectorized branch and are unaffected.